### PR TITLE
Removed the Addition of a Time Dimension and Added Mission Frame Metadata

### DIFF
--- a/cryoforge/generate.py
+++ b/cryoforge/generate.py
@@ -396,7 +396,7 @@ def create_stac_item(ds, geom, url):
         scene_2_frame = scene_2_id.split('_')[5]
     elif mission.startswith('N'):
         scene_1_split = scene_1_id.split('_')
-        scene_2_split = scene_1_id.split('_')
+        scene_2_split = scene_2_id.split('_')
         # CYL_REL_FRM
         # CYL - Orbit cycle
         # REL - Relativate orbit track within cycle

--- a/cryoforge/generate.py
+++ b/cryoforge/generate.py
@@ -397,12 +397,11 @@ def create_stac_item(ds, geom, url):
         scene_1_frame = scene_1_split[5]
         scene_2_frame = scene_2_split[5]
     elif mission.startswith('N'):
-        # CYL_REL_FRM
-        # CYL - Orbit cycle
+        # REL_FRM
         # REL - Relativate orbit track within cycle
         # FRM - Frame number within orbit track
-        scene_1_frame = f'{scene_1_split[4]}_{scene_1_split[5]}_{scene_1_split[7]}'
-        scene_2_frame = f'{scene_2_split[4]}_{scene_2_split[5]}_{scene_2_split[7]}'
+        scene_1_frame = f'{scene_1_split[5]}_{scene_1_split[7]}'
+        scene_2_frame = f'{scene_2_split[5]}_{scene_2_split[7]}'
 
     date_created =  pd.to_datetime(ds.attrs.get("date_created", "")).tz_localize(
         "UTC"

--- a/cryoforge/generate.py
+++ b/cryoforge/generate.py
@@ -493,24 +493,24 @@ def generate_itslive_metadata(url: str, store:Any = None, with_kerchunk: bool=Fa
         store (Any, optional): Optional store for async reading. Defaults to None.
     """
     if store:
-        original_ds, kerchunks = open_async_netcdf(url, store)
+        ds, kerchunks = open_async_netcdf(url, store)
     else:
-        original_ds, kerchunks = open_netcdf(url, with_kerchunk=with_kerchunk)
-    if original_ds is None:
+        ds, kerchunks = open_netcdf(url, with_kerchunk=with_kerchunk)
+    if ds is None:
         raise ValueError(f"Could not open {url}")
 
-    geom = get_geom(original_ds, precision=4, projection=4326)
+    geom = get_geom(ds, precision=4, projection=4326)
     if geom is None:
         raise ValueError(f"Could not extract geometry from {url}")
     geom["url"] = url
-    item = create_stac_item(original_ds, geom, url)
+    item = create_stac_item(ds, geom, url)
     # item.validate() # <- will break because the schema is wrong for the collection property.
-    nsidc_meta = generate_nsidc_metadata_files(original_ds, item.id, item.properties["version"])
+    nsidc_meta = generate_nsidc_metadata_files(ds, item.id, item.properties["version"])
     nsidc_spatial = "\n".join([
         f"{round(coord[0], 2)}\t{round(coord[1], 2)}" for coord in geom["corners"]
     ])
     return {
-        "ds": original_ds,
+        "ds": ds,
         "url": url,
         "stac": item,
         "kerchunk": kerchunks,

--- a/cryoforge/generate.py
+++ b/cryoforge/generate.py
@@ -385,18 +385,18 @@ def create_stac_item(ds, geom, url):
     scene_1_frame = 'N/A'
     scene_2_frame = 'N/A'
 
+    scene_1_split = scene_1_id.split('_')
+    scene_2_split = scene_1_id.split('_')
     if mission.startswith('L'):
-        scene_1_frame = scene_1_id.split('_')[2]
-        scene_2_frame = scene_2_id.split('_')[2]
+        scene_1_frame = scene_1_split[2]
+        scene_2_frame = scene_2_split[2]
     elif mission.startswith('S1'):
         scene_1_frame = ds['img_pair_info']['scene_1_frame']
         scene_2_frame = ds['img_pair_info']['scene_2_frame']
     elif mission.startswith('S2'):
-        scene_1_frame = scene_1_id.split('_')[5]
-        scene_2_frame = scene_2_id.split('_')[5]
+        scene_1_frame = scene_1_split[5]
+        scene_2_frame = scene_2_split[5]
     elif mission.startswith('N'):
-        scene_1_split = scene_1_id.split('_')
-        scene_2_split = scene_2_id.split('_')
         # CYL_REL_FRM
         # CYL - Orbit cycle
         # REL - Relativate orbit track within cycle


### PR DESCRIPTION
This PR removes the addition of a time dimension, since one is now added by `hyp3-autorift` after processing. This PR also replaces the `scene_n_path_row` metadata variable, which was specific to Landsat, with one that has the correct frame info for all of the mission types.